### PR TITLE
Allow reservations fetch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           path: _build
           key: ${{ runner.os }}-build-${{ matrix.otp-version }}-${{ matrix.elixir-version }}-${{ hashFiles(format('{0}/mix.lock', github.workspace)) }}
 
+      - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix compile --warning-as-errors --force
-      - run: mix deps.get
       - run: mix test

--- a/lib/ex_twilio/worker_capability.ex
+++ b/lib/ex_twilio/worker_capability.ex
@@ -165,9 +165,12 @@ defmodule ExTwilio.WorkerCapability do
           workspace_sid: workspace_sid
         }
       ) do
-    policies = allow(policies, task_url(workspace_sid), "POST")
-    policy = add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST")
-    Map.put(capability_struct, :policies, [policy | policies])
+
+    Map.put(capability_struct, :policies, List.flatten([
+      allow(policies, task_url(workspace_sid), "POST"),
+      add_policy(worker_reservation_url(workspace_sid, worker_sid), "GET"),
+      add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST")
+    ]))
   end
 
   @doc """

--- a/lib/ex_twilio/worker_capability.ex
+++ b/lib/ex_twilio/worker_capability.ex
@@ -165,12 +165,15 @@ defmodule ExTwilio.WorkerCapability do
           workspace_sid: workspace_sid
         }
       ) do
-
-    Map.put(capability_struct, :policies, List.flatten([
-      allow(policies, task_url(workspace_sid), "POST"),
-      add_policy(worker_reservation_url(workspace_sid, worker_sid), "GET"),
-      add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST")
-    ]))
+    Map.put(
+      capability_struct,
+      :policies,
+      List.flatten([
+        allow(policies, task_url(workspace_sid), "POST"),
+        add_policy(worker_reservation_url(workspace_sid, worker_sid), "GET"),
+        add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST")
+      ])
+    )
   end
 
   @doc """

--- a/test/ex_twilio/worker_capability_test.exs
+++ b/test/ex_twilio/worker_capability_test.exs
@@ -52,13 +52,13 @@ defmodule ExTwilio.WorkerCapabilityTest do
     assert allow_properties === [true]
   end
 
-  test ".token sets 9 policies" do
+  test ".token sets 10 policies" do
     jwt =
       ExTwilio.WorkerCapability.new("worker_sid", "workspace_sid")
       |> ExTwilio.WorkerCapability.allow_activity_updates()
       |> ExTwilio.WorkerCapability.allow_reservation_updates()
 
-    assert length(decoded_token(jwt).claims["policies"]) == 9
+    assert length(decoded_token(jwt).claims["policies"]) == 10
   end
 
   defp decoded_token(capability) do


### PR DESCRIPTION
### 🐛 Problem

With the existing reservations capabilities, a worker cannot fetch existing reservations.

### 💊 Solution

A thread with Twilio's support team led to the conclusion that a capability was missing in our token.

### 🤖 Beep beep bop

dispatch: `#dispatch/elixir`