### PR TITLE
Include reservations fetch policy

### DIFF
--- a/lib/ex_twilio/worker_capability.ex
+++ b/lib/ex_twilio/worker_capability.ex
@@ -165,9 +165,15 @@ defmodule ExTwilio.WorkerCapability do
           workspace_sid: workspace_sid
         }
       ) do
-    policies = allow(policies, task_url(workspace_sid), "POST")
-    policy = add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST")
-    Map.put(capability_struct, :policies, [policy | policies])
+    Map.put(
+      capability_struct,
+      :policies,
+      List.flatten([
+        allow(policies, task_url(workspace_sid), "POST"),
+        add_policy(worker_reservation_url(workspace_sid, worker_sid), "POST"),
+        add_policy(worker_reservations_url(workspace_sid, worker_sid), "GET")
+      ])
+    )
   end
 
   @doc """
@@ -260,5 +266,9 @@ defmodule ExTwilio.WorkerCapability do
 
   defp worker_reservation_url(workspace_sid, worker_sid) do
     "#{workspaces_base_url(workspace_sid)}/Workers/#{worker_sid}"
+  end
+
+  defp worker_reservations_url(workspace_sid, worker_sid) do
+    "#{workspaces_base_url(workspace_sid)}/Workers/#{worker_sid}/Reservations/**"
   end
 end

--- a/test/ex_twilio/worker_capability_test.exs
+++ b/test/ex_twilio/worker_capability_test.exs
@@ -52,13 +52,13 @@ defmodule ExTwilio.WorkerCapabilityTest do
     assert allow_properties === [true]
   end
 
-  test ".token sets 9 policies" do
+  test ".token sets 10 policies" do
     jwt =
       ExTwilio.WorkerCapability.new("worker_sid", "workspace_sid")
       |> ExTwilio.WorkerCapability.allow_activity_updates()
       |> ExTwilio.WorkerCapability.allow_reservation_updates()
 
-    assert length(decoded_token(jwt).claims["policies"]) == 9
+    assert length(decoded_token(jwt).claims["policies"]) == 10
   end
 
   defp decoded_token(capability) do


### PR DESCRIPTION
In order to be able to fetch existing Reservations for a worker, the 
`"#{workspaces_base_url(workspace_sid)}/Workers/#{worker_sid}/Reservations/**"` must be allowed.

This has been tested in our project.